### PR TITLE
Ensure that the heading has the same width as the grid.

### DIFF
--- a/docs/jsgantt.js
+++ b/docs/jsgantt.js
@@ -722,6 +722,7 @@ exports.GanttChart = function (pDiv, pFormat) {
             if (this.vFormat === 'day') {
                 vTaskLeftPx += 2;
             }
+            vTmpTab.style.width = vTaskLeftPx + 'px'; // Ensure that the headings has exactly the same width as the chart grid
             vTaskPlanLeftPx = (vNumCols * (vColWidth + 3)) + 1;
             if (this.vUseSingleCell != 0 && this.vUseSingleCell < (vNumCols * vNumRows))
                 vSingleCell = true;

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -722,6 +722,7 @@ export const GanttChart = function (pDiv, pFormat) {
       if (this.vFormat === 'day') {
         vTaskLeftPx += 2;
       }
+      vTmpTab.style.width = vTaskLeftPx+'px'; // Ensure that the headings has exactly the same width as the chart grid
       vTaskPlanLeftPx = (vNumCols * (vColWidth + 3)) + 1;
 
       if (this.vUseSingleCell != 0 && this.vUseSingleCell < (vNumCols * vNumRows)) vSingleCell = true;


### PR DESCRIPTION
Fix for #153, force the width of the heading.