### PR TITLE
Error in events.ts file when ng build --prod.

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -194,9 +194,13 @@ const toggleDependencies = function (e) {
     style = '';
   }
   if (ids.length > 1) {
-    document.querySelectorAll(`.gDepId${ids[1]}`).forEach((c: any) => {
+    const frameZones = Array.from(document.querySelectorAll(`.gDepId${ids[1]}`));
+    frameZones.forEach((c: any) => {
       c.style.borderStyle = style;
     });
+   // document.querySelectorAll(`.gDepId${ids[1]}`).forEach((c: any) => {
+     // c.style.borderStyle = style;
+    // });
   }
 }
 


### PR DESCRIPTION
ERROR in node_modules/jsgantt-improved/src/events.ts(197,51): error TS2339: Property 'forEach' does not exist on type 'NodeListOf<Element>'.


Solution:
const frameZones = Array.from(document.querySelectorAll(`.gDepId${ids[1]}`));
    frameZones.forEach((c: any) => {
      c.style.borderStyle = style;
 });
