### PR TITLE
Changed names of the vEvents on click

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -460,10 +460,10 @@ g.setOptions({
         res: console.log,
         dur: console.log,
         comp: console.log,
-        startdate: console.log,
-        enddate: console.log,
-        planstartdate: console.log,
-        planenddate: console.log,
+        start: console.log,
+        end: console.log,
+        planstart: console.log,
+        planend: console.log,
         cost: console.log
       },
   vEventClickRow: console.log


### PR DESCRIPTION
Changed the names of some of the vEvents on click that were outdated.
I'm not sure if there are any more errors in the example but the script seems outdated judging by the live solo example at https://jsganttimproved.github.io/jsgantt-improved/demo.html