### PR TITLE
227 v tooltip template callback

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -297,6 +297,7 @@ The following options take a single numeric parameter; a value of 1 will enable 
 |_setTotalHeight():_ |Set component height as CSS height (e.g. "300px"). If set - the header is fixed and content is scrollable if needed. Otherwise component height is defined by content|
 |_setMinDate():_ |Set minimum date further than minimum task date. It doesn't trim any task if it starts before this minimum date, but can extend the chart to the left. This may be useful if you want to draw some custom elements on the chart or want to fix the time range regardless of the content|
 |_setMaxDate():_ |Similar to _setMinDate()_|
+|_setTooltipTemplate():_ |Set template for the tooltip. Can be <ul><li>*string* - just a static template</li><li>*function(task): string* - function returning template for a given task</li><li>*function(task): Promise&lt;string&gt;* - function returning promise resolving to string. Until promise is resolved tooltip shows `tooltipLoading` from lang section</li></ul>In each case variables inside string are substituted (see example). If function is given and it returns undefined or null - default template is used (like if argument was not passed at all). Function argument is evaluated when tooltip needs to be shown.
 |_setEditable():_  |Set with true if you want to edit values in the data table, will show inputs instead of texts| 
 |_setDebug():_  |Set with true if you want to see debug in console| 
 
@@ -406,7 +407,7 @@ The addLang() method takes two parameters.  The first is a string identifier for
 |_jul_          |Jul               |_startdate_    |Start Date        |_wks_          |Wks               |
 |_aug_          |Aug               |_enddate_      |End Date          |_mths_         |Mths              |
 |_sep_          |Sep               |_moreinfo_     |More Information  |_qtrs_         |Qtrs              |
-|_oct_          |Oct               |_notes_        |Notes             |               |                  |
+|_oct_          |Oct               |_notes_        |Notes             |_tooltipTemplate_|Loading...      |
 |_nov_          |Nov               |               |                  |               |                  |
 |_dec_          |Dec               |               |                  |               |                  |
 

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -189,7 +189,6 @@
     <div class="space"></div>
     <label>Max Date:</label>
     <input type="date" id="vMaxDate" onchange="start(event)" />
-
   </span>
   
   <br />
@@ -197,6 +196,9 @@
   <span>
     <label>Custom Tooltip Template:</label><br />
     <textarea id="tooltiptemplate" onchange="start(event)"><div>Nome: {{pName}}</div> <div>{{Lang:pStart}}: {{pStart}}</div></textarea>
+    <div class="space"></div>
+    <label>Dynamic tooltip:</label>
+    <input type="checkbox" id="dynamicTooltip" checked onchange="start(event)" />
   </span>
 
 

--- a/docs/index.js
+++ b/docs/index.js
@@ -87,7 +87,7 @@ function start(e) {
         cost: console.log,
         beforeDraw: ()=>console.log('before draw listener'),
         afterDraw: ()=> {
-          console.log('before after listener');
+          console.log('after draw listener');
           if (document.querySelector("#customElements:checked")) {
             drawCustomElements(g);
           }
@@ -114,17 +114,10 @@ function start(e) {
       vShowTaskInfoLink, // Show link in tool tip (0/1)
       vShowEndWeekDate,  // Show/Hide the date for the last day of the week in header for daily view (1/0)
       vTooltipDelay: delay,
-      // vTooltipTemplate: newtooltiptemplate,
-      vTooltipTemplate: t => {
-        if (t.getLevel() === 1) return;
-        if (t.getLevel() === 2) return `<div>Name: {{pName}}</div> ${t.getStart() ? '<div>{{Lang:pStart}}: {{pStart}}</div>' : ''}<div>Tooltip generated at: ${new Date()}</div>`;
-        return new Promise((resolve, reject) => {
-          const delay = 3000 + Math.random() * 1000;
-          setTimeout(() => {
-            resolve(`Tooltip content from the promise after ${delay}ms`);
-          }, delay);
-        });
-      },
+      vTooltipTemplate: 
+        document.querySelector("#dynamicTooltip:checked") ?
+          generateTooltip :
+          newtooltiptemplate,
       vDebug,
       vEditable,
       vUseSort,
@@ -204,6 +197,42 @@ function drawCustomElements(g) {
       td.appendChild(div);
     }
   }
+}
+
+function generateTooltip(task) {
+  // default tooltip for level 1
+  if (task.getLevel() === 1) return;
+    
+  // string tooltip for level 2. Show completed/total child count and current timestamp
+  if (task.getLevel() === 2) {
+    let childCount = 0;
+    let complete = 0;
+    for (const item of g.getList()) {
+      if (item.getParent() == task.getID()) {
+        if (item.getCompVal() === 100) {
+          complete++;
+        }
+        childCount++;
+      }
+    }
+    console.log(`Generated dynamic sync template for '${task.getName()}'`);
+    return `
+      <dl>
+        <dt>Name:</dt><dd>{{pName}}</dd>
+        <dt>Complete child tasks:</dt><dd style="color:${complete === childCount ? 'green' : 'red'}">${complete}/${childCount}</dd>
+        <dt>Tooltip generated at:</dt><dd>${new Date()}</dd>
+      </dl>
+    `;
+  }
+  
+  // async tooltip for level 3 and below
+  return new Promise((resolve, reject) => {
+    const delay = Math.random() * 3000;
+    setTimeout(() => {
+      console.log(`Generated dynamic async template for '${task.getName()}'`);
+      resolve(`Tooltip content from the promise after ${Math.round(delay)}ms`);
+    }, delay);
+  });
 }
 
 start('pt')

--- a/docs/index.js
+++ b/docs/index.js
@@ -114,7 +114,17 @@ function start(e) {
       vShowTaskInfoLink, // Show link in tool tip (0/1)
       vShowEndWeekDate,  // Show/Hide the date for the last day of the week in header for daily view (1/0)
       vTooltipDelay: delay,
-      vTooltipTemplate: newtooltiptemplate,
+      // vTooltipTemplate: newtooltiptemplate,
+      vTooltipTemplate: t => {
+        if (t.getLevel() === 1) return;
+        if (t.getLevel() === 2) return `<div>Name: {{pName}}</div> ${t.getStart() ? '<div>{{Lang:pStart}}: {{pStart}}</div>' : ''}<div>Tooltip generated at: ${new Date()}</div>`;
+        return new Promise((resolve, reject) => {
+          const delay = 3000 + Math.random() * 1000;
+          setTimeout(() => {
+            resolve(`Tooltip content from the promise after ${delay}ms`);
+          }, delay);
+        });
+      },
       vDebug,
       vEditable,
       vUseSort,

--- a/docs/jsgantt.js
+++ b/docs/jsgantt.js
@@ -1,4 +1,4 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.JSGantt = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.JSGantt = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var jsGantt = require("./src/jsgantt");
@@ -3184,72 +3184,88 @@ exports.TaskItem = function (pID, pName, pStart, pEnd, pClass, pLink, pMile, pRe
         };
     };
 };
-exports.createTaskInfo = function (pTask, template) {
+exports.createTaskInfo = function (pTask, templateStrOrFn) {
     var _this = this;
-    if (template === void 0) { template = null; }
+    if (templateStrOrFn === void 0) { templateStrOrFn = null; }
     var vTmpDiv;
     var vTaskInfoBox = document.createDocumentFragment();
     var vTaskInfo = this.newNode(vTaskInfoBox, 'div', null, 'gTaskInfo');
-    if (template) {
-        var allData_1 = pTask.getAllData();
-        utils_1.internalProperties.forEach(function (key) {
-            var lang;
-            if (utils_1.internalPropertiesLang[key]) {
-                lang = _this.vLangs[_this.vLang][utils_1.internalPropertiesLang[key]];
+    var setupTemplate = function (template) {
+        if (template) {
+            var allData_1 = pTask.getAllData();
+            utils_1.internalProperties.forEach(function (key) {
+                var lang;
+                if (utils_1.internalPropertiesLang[key]) {
+                    lang = _this.vLangs[_this.vLang][utils_1.internalPropertiesLang[key]];
+                }
+                if (!lang) {
+                    lang = key;
+                }
+                var val = allData_1[key];
+                template = template.replace("{{" + key + "}}", val);
+                if (lang) {
+                    template = template.replace("{{Lang:" + key + "}}", lang);
+                }
+                else {
+                    template = template.replace("{{Lang:" + key + "}}", key);
+                }
+            });
+            vTaskInfo.innerHTML = "";
+            _this.newNode(vTaskInfo, 'span', null, 'gTtTemplate', template);
+        }
+        else {
+            _this.newNode(vTaskInfo, 'span', null, 'gTtTitle', pTask.getName());
+            if (_this.vShowTaskInfoStartDate == 1) {
+                vTmpDiv = _this.newNode(vTaskInfo, 'div', null, 'gTILine gTIsd');
+                _this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', _this.vLangs[_this.vLang]['startdate'] + ': ');
+                _this.newNode(vTmpDiv, 'span', null, 'gTaskText', utils_1.formatDateStr(pTask.getStart(), _this.vDateTaskDisplayFormat, _this.vLangs[_this.vLang]));
             }
-            if (!lang) {
-                lang = key;
+            if (_this.vShowTaskInfoEndDate == 1) {
+                vTmpDiv = _this.newNode(vTaskInfo, 'div', null, 'gTILine gTIed');
+                _this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', _this.vLangs[_this.vLang]['enddate'] + ': ');
+                _this.newNode(vTmpDiv, 'span', null, 'gTaskText', utils_1.formatDateStr(pTask.getEnd(), _this.vDateTaskDisplayFormat, _this.vLangs[_this.vLang]));
             }
-            var val = allData_1[key];
-            template = template.replace("{{" + key + "}}", val);
-            if (lang) {
-                template = template.replace("{{Lang:" + key + "}}", lang);
+            if (_this.vShowTaskInfoDur == 1 && !pTask.getMile()) {
+                vTmpDiv = _this.newNode(vTaskInfo, 'div', null, 'gTILine gTId');
+                _this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', _this.vLangs[_this.vLang]['duration'] + ': ');
+                _this.newNode(vTmpDiv, 'span', null, 'gTaskText', pTask.getDuration(_this.vFormat, _this.vLangs[_this.vLang]));
             }
-            else {
-                template = template.replace("{{Lang:" + key + "}}", key);
+            if (_this.vShowTaskInfoComp == 1) {
+                vTmpDiv = _this.newNode(vTaskInfo, 'div', null, 'gTILine gTIc');
+                _this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', _this.vLangs[_this.vLang]['completion'] + ': ');
+                _this.newNode(vTmpDiv, 'span', null, 'gTaskText', pTask.getCompStr());
             }
-        });
-        this.newNode(vTaskInfo, 'span', null, 'gTtTemplate', template);
+            if (_this.vShowTaskInfoRes == 1) {
+                vTmpDiv = _this.newNode(vTaskInfo, 'div', null, 'gTILine gTIr');
+                _this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', _this.vLangs[_this.vLang]['resource'] + ': ');
+                _this.newNode(vTmpDiv, 'span', null, 'gTaskText', pTask.getResource());
+            }
+            if (_this.vShowTaskInfoLink == 1 && pTask.getLink() != '') {
+                vTmpDiv = _this.newNode(vTaskInfo, 'div', null, 'gTILine gTIl');
+                var vTmpNode = _this.newNode(vTmpDiv, 'span', null, 'gTaskLabel');
+                vTmpNode = _this.newNode(vTmpNode, 'a', null, 'gTaskText', _this.vLangs[_this.vLang]['moreinfo']);
+                vTmpNode.setAttribute('href', pTask.getLink());
+            }
+            if (_this.vShowTaskInfoNotes == 1) {
+                vTmpDiv = _this.newNode(vTaskInfo, 'div', null, 'gTILine gTIn');
+                _this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', _this.vLangs[_this.vLang]['notes'] + ': ');
+                if (pTask.getNotes())
+                    vTmpDiv.appendChild(pTask.getNotes());
+            }
+        }
+    };
+    if (typeof templateStrOrFn === 'function') {
+        var strOrPromise = templateStrOrFn(pTask);
+        if (!strOrPromise || typeof strOrPromise === 'string') {
+            setupTemplate(strOrPromise);
+        }
+        else if (strOrPromise.then) {
+            setupTemplate("Loading...");
+            strOrPromise.then(setupTemplate);
+        }
     }
     else {
-        this.newNode(vTaskInfo, 'span', null, 'gTtTitle', pTask.getName());
-        if (this.vShowTaskInfoStartDate == 1) {
-            vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIsd');
-            this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['startdate'] + ': ');
-            this.newNode(vTmpDiv, 'span', null, 'gTaskText', utils_1.formatDateStr(pTask.getStart(), this.vDateTaskDisplayFormat, this.vLangs[this.vLang]));
-        }
-        if (this.vShowTaskInfoEndDate == 1) {
-            vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIed');
-            this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['enddate'] + ': ');
-            this.newNode(vTmpDiv, 'span', null, 'gTaskText', utils_1.formatDateStr(pTask.getEnd(), this.vDateTaskDisplayFormat, this.vLangs[this.vLang]));
-        }
-        if (this.vShowTaskInfoDur == 1 && !pTask.getMile()) {
-            vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTId');
-            this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['duration'] + ': ');
-            this.newNode(vTmpDiv, 'span', null, 'gTaskText', pTask.getDuration(this.vFormat, this.vLangs[this.vLang]));
-        }
-        if (this.vShowTaskInfoComp == 1) {
-            vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIc');
-            this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['completion'] + ': ');
-            this.newNode(vTmpDiv, 'span', null, 'gTaskText', pTask.getCompStr());
-        }
-        if (this.vShowTaskInfoRes == 1) {
-            vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIr');
-            this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['resource'] + ': ');
-            this.newNode(vTmpDiv, 'span', null, 'gTaskText', pTask.getResource());
-        }
-        if (this.vShowTaskInfoLink == 1 && pTask.getLink() != '') {
-            vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIl');
-            var vTmpNode = this.newNode(vTmpDiv, 'span', null, 'gTaskLabel');
-            vTmpNode = this.newNode(vTmpNode, 'a', null, 'gTaskText', this.vLangs[this.vLang]['moreinfo']);
-            vTmpNode.setAttribute('href', pTask.getLink());
-        }
-        if (this.vShowTaskInfoNotes == 1) {
-            vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIn');
-            this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['notes'] + ': ');
-            if (pTask.getNotes())
-                vTmpDiv.appendChild(pTask.getNotes());
-        }
+        setupTemplate(templateStrOrFn);
     }
     return vTaskInfoBox;
 };

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -961,8 +961,9 @@ export const GanttChart = function (pDiv, pFormat) {
         // Add Task Info div for tooltip
         if (this.vTaskList[i].getTaskDiv() && vTmpDiv) {
           vTmpDiv2 = this.newNode(vTmpDiv, 'div', this.vDivId + 'tt' + vID, null, null, null, null, 'none');
-          vTmpDiv2.appendChild(this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate));
-          addTooltipListeners(this, this.vTaskList[i].getTaskDiv(), vTmpDiv2);
+          const {component, callback} = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate);
+          vTmpDiv2.appendChild(component);
+          addTooltipListeners(this, this.vTaskList[i].getTaskDiv(), vTmpDiv2, callback);
         }
       }
       if (this.vDebug) {

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -142,7 +142,8 @@ const en =
   'wed': 'Wed',
   'thu': 'Thu',
   'fri': 'Fri',
-  'sat': 'Sat'
+  'sat': 'Sat',
+  'tooltipLoading': 'Loading...'
 }
 
 const de = {
@@ -349,7 +350,8 @@ const ru = {
   'dys': 'дн.',
   'wks': 'нед.',
   'mths': 'мес.',
-  'qtrs': 'кв.'
+  'qtrs': 'кв.',
+  'tooltipLoading': 'Загрузка...'
 }
 
 const fr = {

--- a/src/task.ts
+++ b/src/task.ts
@@ -468,70 +468,85 @@ export const TaskItem = function (pID, pName, pStart, pEnd, pClass, pLink, pMile
 };
 
 
-export const createTaskInfo = function (pTask, template = null) {
+export const createTaskInfo = function (pTask, templateStrOrFn = null) {
   let vTmpDiv;
   let vTaskInfoBox = document.createDocumentFragment();
   let vTaskInfo = this.newNode(vTaskInfoBox, 'div', null, 'gTaskInfo');
 
-  if (template) {
-    let allData = pTask.getAllData()
-    internalProperties.forEach(key => {
-      let lang;
-      if (internalPropertiesLang[key]) {
-        lang = this.vLangs[this.vLang][internalPropertiesLang[key]];
-      }
+  const setupTemplate = template => {
+    if (template) {
+      let allData = pTask.getAllData()
+      internalProperties.forEach(key => {
+        let lang;
+        if (internalPropertiesLang[key]) {
+          lang = this.vLangs[this.vLang][internalPropertiesLang[key]];
+        }
 
-      if (!lang) {
-        lang = key
-      }
-      const val = allData[key];
+        if (!lang) {
+          lang = key
+        }
+        const val = allData[key];
 
-      template = template.replace(`{{${key}}}`, val);
-      if (lang) {
-        template = template.replace(`{{Lang:${key}}}`, lang);
-      } else {
-        template = template.replace(`{{Lang:${key}}}`, key);
+        template = template.replace(`{{${key}}}`, val);
+        if (lang) {
+          template = template.replace(`{{Lang:${key}}}`, lang);
+        } else {
+          template = template.replace(`{{Lang:${key}}}`, key);
+        }
+      });
+      vTaskInfo.innerHTML = "";
+      this.newNode(vTaskInfo, 'span', null, 'gTtTemplate', template);
+    } else {
+      this.newNode(vTaskInfo, 'span', null, 'gTtTitle', pTask.getName());
+      if (this.vShowTaskInfoStartDate == 1) {
+        vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIsd');
+        this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['startdate'] + ': ');
+        this.newNode(vTmpDiv, 'span', null, 'gTaskText', formatDateStr(pTask.getStart(), this.vDateTaskDisplayFormat, this.vLangs[this.vLang]));
       }
-    });
-    this.newNode(vTaskInfo, 'span', null, 'gTtTemplate', template);
+      if (this.vShowTaskInfoEndDate == 1) {
+        vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIed');
+        this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['enddate'] + ': ');
+        this.newNode(vTmpDiv, 'span', null, 'gTaskText', formatDateStr(pTask.getEnd(), this.vDateTaskDisplayFormat, this.vLangs[this.vLang]));
+      }
+      if (this.vShowTaskInfoDur == 1 && !pTask.getMile()) {
+        vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTId');
+        this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['duration'] + ': ');
+        this.newNode(vTmpDiv, 'span', null, 'gTaskText', pTask.getDuration(this.vFormat, this.vLangs[this.vLang]));
+      }
+      if (this.vShowTaskInfoComp == 1) {
+        vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIc');
+        this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['completion'] + ': ');
+        this.newNode(vTmpDiv, 'span', null, 'gTaskText', pTask.getCompStr());
+      }
+      if (this.vShowTaskInfoRes == 1) {
+        vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIr');
+        this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['resource'] + ': ');
+        this.newNode(vTmpDiv, 'span', null, 'gTaskText', pTask.getResource());
+      }
+      if (this.vShowTaskInfoLink == 1 && pTask.getLink() != '') {
+        vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIl');
+        let vTmpNode = this.newNode(vTmpDiv, 'span', null, 'gTaskLabel');
+        vTmpNode = this.newNode(vTmpNode, 'a', null, 'gTaskText', this.vLangs[this.vLang]['moreinfo']);
+        vTmpNode.setAttribute('href', pTask.getLink());
+      }
+      if (this.vShowTaskInfoNotes == 1) {
+        vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIn');
+        this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['notes'] + ': ');
+        if (pTask.getNotes()) vTmpDiv.appendChild(pTask.getNotes());
+      }
+    }
+  };
+
+  if (typeof templateStrOrFn === 'function') {
+    const strOrPromise = templateStrOrFn(pTask);
+    if (!strOrPromise || typeof strOrPromise === 'string') {
+      setupTemplate(strOrPromise);
+    } else if (strOrPromise.then) {
+      setupTemplate("Loading...");
+      strOrPromise.then(setupTemplate);
+    }
   } else {
-    this.newNode(vTaskInfo, 'span', null, 'gTtTitle', pTask.getName());
-    if (this.vShowTaskInfoStartDate == 1) {
-      vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIsd');
-      this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['startdate'] + ': ');
-      this.newNode(vTmpDiv, 'span', null, 'gTaskText', formatDateStr(pTask.getStart(), this.vDateTaskDisplayFormat, this.vLangs[this.vLang]));
-    }
-    if (this.vShowTaskInfoEndDate == 1) {
-      vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIed');
-      this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['enddate'] + ': ');
-      this.newNode(vTmpDiv, 'span', null, 'gTaskText', formatDateStr(pTask.getEnd(), this.vDateTaskDisplayFormat, this.vLangs[this.vLang]));
-    }
-    if (this.vShowTaskInfoDur == 1 && !pTask.getMile()) {
-      vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTId');
-      this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['duration'] + ': ');
-      this.newNode(vTmpDiv, 'span', null, 'gTaskText', pTask.getDuration(this.vFormat, this.vLangs[this.vLang]));
-    }
-    if (this.vShowTaskInfoComp == 1) {
-      vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIc');
-      this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['completion'] + ': ');
-      this.newNode(vTmpDiv, 'span', null, 'gTaskText', pTask.getCompStr());
-    }
-    if (this.vShowTaskInfoRes == 1) {
-      vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIr');
-      this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['resource'] + ': ');
-      this.newNode(vTmpDiv, 'span', null, 'gTaskText', pTask.getResource());
-    }
-    if (this.vShowTaskInfoLink == 1 && pTask.getLink() != '') {
-      vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIl');
-      let vTmpNode = this.newNode(vTmpDiv, 'span', null, 'gTaskLabel');
-      vTmpNode = this.newNode(vTmpNode, 'a', null, 'gTaskText', this.vLangs[this.vLang]['moreinfo']);
-      vTmpNode.setAttribute('href', pTask.getLink());
-    }
-    if (this.vShowTaskInfoNotes == 1) {
-      vTmpDiv = this.newNode(vTaskInfo, 'div', null, 'gTILine gTIn');
-      this.newNode(vTmpDiv, 'span', null, 'gTaskLabel', this.vLangs[this.vLang]['notes'] + ': ');
-      if (pTask.getNotes()) vTmpDiv.appendChild(pTask.getNotes());
-    }
+    setupTemplate(templateStrOrFn);
   }
 
   return vTaskInfoBox;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -549,3 +549,10 @@ export const criticalPath = function (tasks) {
     }
   }
 }
+
+export function isParentElementOrSelf(child, parent) {
+  while (child) {
+    if (child === parent) return true;
+    child = child.parentElement;
+  }
+}


### PR DESCRIPTION
Set template for the tooltip. 

- *string* - just a static template
- *function(task): string* - function returning template for a given task
- *function(task): Promise<string>* - function returning promise resolving to string. Until promise is resolved tooltip shows `tooltipLoading` from lang section

In each case variables inside string are substituted (see example). If function is given and it returns undefined or null - default template is used (like if argument was not passed at all). Function argument is evaluated when tooltip needs to be shown.