### PR TITLE
Reset vToolCont showing attribute on tooltip hide

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -447,6 +447,7 @@ export const hideToolTip = function (pGanttChartObj, pTool, pTimer) {
     pTool.style.opacity = 0;
     pTool.style.filter = 'alpha(opacity=0)';
     pTool.style.visibility = 'hidden';
+    pTool.vToolCont.setAttribute("showing", null);
   }
 };
 
@@ -473,6 +474,7 @@ export const fadeToolTip = function (pDirection, pTool, pMaxAlpha) {
       pTool.style.opacity = 0;
       pTool.style.filter = 'alpha(opacity=0)';
       pTool.style.visibility = 'hidden';
+      pTool.vToolCont.setAttribute("showing", null);
     }
   }
 };


### PR DESCRIPTION
At the moment when you hover from tooltip and back tooltip shows the same stuff, because it doesn't update tooltip content if `showing` attribute in tooltip element doesn't change (same task). It messes with use case when you remove and then add back task with the same ID.

This pull requests resets `showing` when hiding tooltip. It forces tooltip content to be recreated on hover.

Fixes #226