### PR TITLE
Scrollbar calculation container styles are moved to CSS

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -539,3 +539,11 @@ You can change the CSS and choose the size:
 ```
 
 Reference: https://github.com/jsGanttImproved/jsgantt-improved/issues/157
+
+* Table headers are missing when vTotalHeight is set
+
+There's a piece of code to calculate scrollbar size, which creates a temporary div in body.
+
+Some styles may mess with this div and cause incorrect calculation.
+
+This temp div has class `gscrollbar-calculation-container`, so if you have top level styles you can't controll - you may add styles to this class to fix scrollbar calculation.

--- a/docs/jsgantt.css
+++ b/docs/jsgantt.css
@@ -945,11 +945,6 @@ td.gspanning div {
   border-radius: 8px; 
 }
 
-.frame::-webkit-scrollbar-track {
-  background-color: #fff;
-  border-radius: 8px;
-}
-
 .gscrollbar-calculation-container {
   visibility: hidden;
   overflow: scroll;

--- a/docs/jsgantt.css
+++ b/docs/jsgantt.css
@@ -914,3 +914,10 @@ td.gspanning div {
   background-color: #fff; 
   border-radius: 8px; 
 }
+
+.gscrollbar-calculation-container {
+  visibility: hidden;
+  overflow: scroll;
+  -ms-overflow-style: scrollbar;
+  display: block;
+}

--- a/docs/jsgantt.js
+++ b/docs/jsgantt.js
@@ -1,4 +1,4 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.JSGantt = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.JSGantt = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var jsGantt = require("./src/jsgantt");
@@ -3828,9 +3828,7 @@ exports.getScrollbarWidth = function () {
     if (scrollbarWidth)
         return scrollbarWidth;
     var outer = document.createElement('div');
-    outer.style.visibility = 'hidden';
-    outer.style.overflow = 'scroll'; // forcing scrollbar to appear
-    outer.style.msOverflowStyle = 'scrollbar'; // needed for WinJS apps
+    outer.className = 'gscrollbar-calculation-container';
     document.body.appendChild(outer);
     // Creating inner element and placing it in the container
     var inner = document.createElement('div');

--- a/src/jsgantt.css
+++ b/src/jsgantt.css
@@ -945,11 +945,6 @@ td.gspanning div {
   border-radius: 8px; 
 }
 
-.frame::-webkit-scrollbar-track {
-  background-color: #fff;
-  border-radius: 8px;
-}
-
 .gscrollbar-calculation-container {
   visibility: hidden;
   overflow: scroll;

--- a/src/jsgantt.css
+++ b/src/jsgantt.css
@@ -914,3 +914,10 @@ td.gspanning div {
   background-color: #fff; 
   border-radius: 8px; 
 }
+
+.gscrollbar-calculation-container {
+  visibility: hidden;
+  overflow: scroll;
+  -ms-overflow-style: scrollbar;
+  display: block;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -362,9 +362,7 @@ export const getScrollbarWidth = function () {
   if (scrollbarWidth) return scrollbarWidth;
 
   const outer = document.createElement('div');
-  outer.style.visibility = 'hidden';
-  outer.style.overflow = 'scroll'; // forcing scrollbar to appear
-  outer.style.msOverflowStyle = 'scrollbar'; // needed for WinJS apps
+  outer.className = 'gscrollbar-calculation-container';
   document.body.appendChild(outer);
 
   // Creating inner element and placing it in the container


### PR DESCRIPTION
Move scrollbar calculation container styles into CSS, so it can be patched if there are any overlapping styles. Also add `display: block` style for this element.

For example in the project i'm working on we have `body > * { display: flex; }`, which i can't control. It breaks scrollbar calculation. When styles are set from JS - there's nothing i can do, but with CSS class i can patch all these overlapping styles.

Fixes #238 