### PR TITLE
Midnight bug and format buttons enhancement.

### DIFF
--- a/src/draw.ts
+++ b/src/draw.ts
@@ -245,17 +245,8 @@ export const GanttChart = function (pDiv, pFormat) {
       let vTmpTBody = newNode(vTmpTab, 'tbody');
       let vTmpRow = newNode(vTmpTBody, 'tr');
       newNode(vTmpRow, 'td', null, 'gtasklist', '\u00A0');
-      /* Add colspan on new node to cover all columns */
       let vTmpCell = newNode(vTmpRow, 'td', null, 'gspanning gtaskname', null, null, null, null, this.getColumnOrder().length + 1);
       vTmpCell.appendChild(this.drawSelector('top'));
-
-      /* Remove empty columns for colspan to work
-      this.getColumnOrder().forEach(column => {
-        if (this[column] == 1 || column === 'vAdditionalHeaders') {
-          draw_list_headings(column, vTmpRow, this.vAdditionalHeaders);
-        }
-      }); */
-
 
       vTmpRow = newNode(vTmpTBody, 'tr');
       newNode(vTmpRow, 'td', null, 'gtasklist', '\u00A0');

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -559,7 +559,6 @@ export const GanttChart = function (pDiv, pFormat) {
       for (i = 0; i < this.vTaskList.length; i++) {
         let curTaskStart = this.vTaskList[i].getStart() ? this.vTaskList[i].getStart() : this.vTaskList[i].getPlanStart();
         let curTaskEnd = this.vTaskList[i].getEnd() ? this.vTaskList[i].getEnd() : this.vTaskList[i].getPlanEnd();
-        if ((curTaskEnd.getTime() - (curTaskEnd.getTimezoneOffset() * 60000)) % (86400000) == 0) curTaskEnd = new Date(curTaskEnd.getFullYear(), curTaskEnd.getMonth(), curTaskEnd.getDate() + 1, curTaskEnd.getHours(), curTaskEnd.getMinutes(), curTaskEnd.getSeconds()); // add 1 day here to simplify calculations below
 
         vTaskLeftPx = getOffset(vMinDate, curTaskStart, vColWidth, this.vFormat, this.vShowWeekends);
         vTaskRightPx = getOffset(curTaskStart, curTaskEnd, vColWidth, this.vFormat, this.vShowWeekends);
@@ -570,8 +569,6 @@ export const GanttChart = function (pDiv, pFormat) {
         curTaskPlanEnd = this.vTaskList[i].getPlanEnd();
 
         if (curTaskPlanStart && curTaskPlanEnd) {
-          if ((curTaskPlanEnd.getTime() - (curTaskPlanEnd.getTimezoneOffset() * 60000)) % (86400000) == 0) curTaskPlanEnd = new Date(curTaskPlanEnd.getFullYear(), curTaskPlanEnd.getMonth(), curTaskPlanEnd.getDate() + 1, curTaskPlanEnd.getHours(), curTaskPlanEnd.getMinutes(), curTaskPlanEnd.getSeconds()); // add 1 day here to simplify calculations below
-
           vTaskPlanLeftPx = getOffset(vMinDate, curTaskPlanStart, vColWidth, this.vFormat, this.vShowWeekends);
           vTaskPlanRightPx = getOffset(curTaskPlanStart, curTaskPlanEnd, vColWidth, this.vFormat, this.vShowWeekends);
         } else {

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -245,14 +245,16 @@ export const GanttChart = function (pDiv, pFormat) {
       let vTmpTBody = newNode(vTmpTab, 'tbody');
       let vTmpRow = newNode(vTmpTBody, 'tr');
       newNode(vTmpRow, 'td', null, 'gtasklist', '\u00A0');
-      let vTmpCell = newNode(vTmpRow, 'td', null, 'gspanning gtaskname');
+      /* Add colspan on new node to cover all columns */
+      let vTmpCell = newNode(vTmpRow, 'td', null, 'gspanning gtaskname', null, null, null, null, this.getColumnOrder().length + 1);
       vTmpCell.appendChild(this.drawSelector('top'));
 
+      /* Remove empty columns for colspan to work
       this.getColumnOrder().forEach(column => {
         if (this[column] == 1 || column === 'vAdditionalHeaders') {
           draw_list_headings(column, vTmpRow, this.vAdditionalHeaders);
         }
-      });
+      }); */
 
 
       vTmpRow = newNode(vTmpTBody, 'tr');


### PR DESCRIPTION
FIX: all end dates that finished on 00:00:00 would add 1 day to the date causing the gantt to show 1 more day than it was. Removed the code where it was added 1 day for the dates.

ENHANCEMENT: the format buttons width was equal to the task name column, which in some cases could be small for all the buttons to show. Added column span to the format buttons column and remove the other invisible columns, that way that column have all the space until the calendar to show.