### PR TITLE
Refine dates precision to one second

### DIFF
--- a/dist/jsgantt.js
+++ b/dist/jsgantt.js
@@ -3852,6 +3852,9 @@ exports.parseDateStr = function (pDateStr, pFormatStr) {
             case 'yyyy-mm-dd':
                 vDate = new Date(vDateParts[0], vDateParts[1] - 1, vDateParts[2], vDateParts[3], vDateParts[4]);
                 break;
+            case 'yyyy-mm-dd HH:MI:SS':
+                vDate = new Date(vDateParts[0], vDateParts[1] - 1, vDateParts[2], vDateParts[3], vDateParts[4], vDateParts[5]);
+                break;
         }
     }
     return (vDate);
@@ -3922,6 +3925,12 @@ exports.formatDateStr = function (pDate, pDateFormatArr, pL) {
                     vDateStr += '0'; // now fall through
             case 'mi':
                 vDateStr += pDate.getMinutes();
+                break;
+            case 'SS':
+                if (pDate.getSeconds() < 10)
+                    vDateStr += '0'; // now fall through
+            case 'ss':
+                vDateStr += pDate.getSeconds();
                 break;
             case 'pm':
                 vDateStr += ((pDate.getHours()) < 12) ? 'am' : 'pm';
@@ -4897,7 +4906,7 @@ exports.getXMLTask = function (pID, pIdx) {
     var i = 0;
     var vIdx = -1;
     var vTask = '';
-    var vOutFrmt = date_utils_1.parseDateFormatStr(this.getDateInputFormat() + ' HH:MI');
+    var vOutFrmt = date_utils_1.parseDateFormatStr(this.getDateInputFormat() + ' HH:MI:SS');
     if (pIdx === true)
         vIdx = pID;
     else {

--- a/src/utils/date_utils.ts
+++ b/src/utils/date_utils.ts
@@ -124,6 +124,9 @@ export const parseDateStr = function (pDateStr, pFormatStr) {
       case 'yyyy-mm-dd':
         vDate = new Date(vDateParts[0], vDateParts[1] - 1, vDateParts[2], vDateParts[3], vDateParts[4]);
         break;
+      case 'yyyy-mm-dd HH:MI:SS':
+        vDate = new Date(vDateParts[0], vDateParts[1] - 1, vDateParts[2], vDateParts[3], vDateParts[4], vDateParts[5]);
+        break;
     }
   }
   return (vDate);
@@ -193,6 +196,12 @@ export const formatDateStr = function (pDate, pDateFormatArr, pL) {
       case 'mi':
         vDateStr += pDate.getMinutes();
         break;
+      case 'SS':
+        if (pDate.getSeconds() < 10)
+          vDateStr += '0'; // now fall through
+      case 'ss':
+          vDateStr += pDate.getSeconds();
+          break;
       case 'pm':
         vDateStr += ((pDate.getHours()) < 12) ? 'am' : 'pm';
         break;

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -280,7 +280,7 @@ export const getXMLTask = function (pID, pIdx) {
   let i = 0;
   let vIdx = -1;
   let vTask = '';
-  let vOutFrmt = parseDateFormatStr(this.getDateInputFormat() + ' HH:MI');
+  let vOutFrmt = parseDateFormatStr(this.getDateInputFormat() + ' HH:MI:SS');
   if (pIdx === true) vIdx = pID;
   else {
     for (i = 0; i < this.vTaskList.length; i++) {


### PR DESCRIPTION
Refine the current precision of date formats (minute) to a more accurate unit (second)
Impacts:
- date_utils.ts => parseDateStr, formatDateStr
- xml.ts => getXMLTask