### PR TITLE
Bugfix: Wrong start/end calculation when using planned dates in tasks.

### DIFF
--- a/src/utils/date_utils.ts
+++ b/src/utils/date_utils.ts
@@ -12,6 +12,7 @@ export const getMinDate = function (pList, pFormat, pMinDate) {
   // Parse all Task Start dates to find min
   for (let i = 0; i < pList.length; i++) {
     if (pList[i].getStart().getTime() < vDate.getTime()) vDate.setTime(pList[i].getStart().getTime());
+    if (pList[i].getPlanStart().getTime() < vDate.getTime()) vDate.setTime(pList[i].getPlanStart().getTime());
   }
 
   // Adjust min date to specific format boundaries (first of week or first of month)
@@ -58,6 +59,7 @@ export const getMaxDate = function (pList, pFormat, pMaxDate) {
   // Parse all Task End dates to find max
   for (let i = 0; i < pList.length; i++) {
     if (pList[i].getEnd().getTime() > vDate.getTime()) vDate.setTime(pList[i].getEnd().getTime());
+    if (pList[i].getPlanEnd().getTime() > vDate.getTime()) vDate.setTime(pList[i].getPlanEnd().getTime());
   }
 
   // Adjust max date to specific format boundaries (end of week or end of month)


### PR DESCRIPTION
When using the task.planStart and task.planEnd fields the beginning/end of the gantt chart was caclulated incorrectly. 
The issue can be reproduced by using the example code on the webpage and switching to "day" view:

```
// Or Adding  Manually
g.AddTaskItemObject({
  pID: 1,
  pName: "Define Chart <strong>API</strong>",
  pStart: "2017-02-25",
  pEnd: "2017-03-17",
  pPlanStart: "2017-04-01",
  pPlanEnd: "2017-04-15 12:00",
  pClass: "ggroupblack",
  pLink: "",
  pMile: 0,
  pRes: "Brian",
  pComp: 0,
  pGroup: 0,
  pParent: 0,
  pOpen: 1,
  pDepend: "",
  pCaption: "",
  pCost: 1000,
  pNotes: "Some Notes text",
  category: "My Category",
  sector: "Finance"
});

```



Solution: Both getMinDate and getMaxDate now take planned and real dates into consideration.

