### PR TITLE
Showtooltip improvement for large task list

### DIFF
--- a/src/draw.ts
+++ b/src/draw.ts
@@ -677,14 +677,18 @@ export const GanttChart = function (pDiv, pFormat) {
       if (this.vTaskList[i].getTaskDiv() && vTmpDiv) {
         const vTmpDiv2 = newNode(vTmpDiv, 'div', this.vDivId + 'tt' + vID, null, null, null, null, 'none');
         const { component, callback } = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate);
-        vTmpDiv2.appendChild(component);
+        const el = document.createElement('div');
+        el.appendChild(component);
+        vTmpDiv2.setAttribute('data-tooltip', el.innerHTML)
         addTooltipListeners(this, this.vTaskList[i].getTaskDiv(), vTmpDiv2, callback);
       }
       // Add Plan Task Info div for tooltip
       if (this.vTaskList[i].getPlanTaskDiv() && vTmpDiv) {
         const vTmpDiv2 = newNode(vTmpDiv, 'div', this.vDivId + 'tt' + vID, null, null, null, null, 'none');
         const { component, callback } = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate);
-        vTmpDiv2.appendChild(component);
+        const el = document.createElement('div');
+        el.appendChild(component);
+        vTmpDiv2.setAttribute('data-tooltip', el.innerHTML)
         addTooltipListeners(this, this.vTaskList[i].getPlanTaskDiv(), vTmpDiv2, callback);
       }
     }

--- a/src/events.ts
+++ b/src/events.ts
@@ -143,9 +143,10 @@ export const showToolTip = function (pGanttChartObj, e, pContents, pWidth, pTime
     }
     clearTimeout(pGanttChartObj.vTool.delayTimeout);
 
-    const newHTML = pContents.innerHTML;
+    const newHTML = pContents.getAttribute('data-tooltip');
+
     if (pGanttChartObj.vTool.vToolCont.getAttribute("content") !== newHTML) {
-      pGanttChartObj.vTool.vToolCont.innerHTML = pContents.innerHTML;
+      pGanttChartObj.vTool.vToolCont.innerHTML = pContents.getAttribute('data-tooltip');
       // as we are allowing arbitrary HTML we should remove any tag ids to prevent duplication
       stripIds(pGanttChartObj.vTool.vToolCont);
       pGanttChartObj.vTool.vToolCont.setAttribute("content", newHTML);

--- a/src/utils/general_utils.ts
+++ b/src/utils/general_utils.ts
@@ -315,6 +315,10 @@ export const updateFlyingObj = function (e, pGanttChartObj, pTimer) {
   let vViewportY = document.documentElement.clientHeight || document.getElementsByTagName('body')[0].clientHeight;
   let vNewX = vMouseX;
   let vNewY = vMouseY;
+  let screenX = screen.availWidth || window.innerWidth;
+  let screenY = screen.availHeight || window.innerHeight;
+  let vOldX = parseInt(pGanttChartObj.vTool.style.left);
+  let vOldY = parseInt(pGanttChartObj.vTool.style.top);
 
   if (navigator.appName.toLowerCase() == 'microsoft internet explorer') {
     // the clientX and clientY properties include the left and top borders of the client area
@@ -363,8 +367,9 @@ export const updateFlyingObj = function (e, pGanttChartObj, pTimer) {
 	}
 	else vNewY=vMouseY+vScrollPos.y-vCurTopBuf-pGanttChartObj.vTool.offsetHeight;
 	*/
+  let outViewport = Math.abs(vOldX - vNewX) > screenX || Math.abs(vOldY - vNewY) > screenY
 
-  if (pGanttChartObj.getUseMove()) {
+  if (pGanttChartObj.getUseMove() && !outViewport) {
     clearInterval(pGanttChartObj.vTool.moveInterval);
     pGanttChartObj.vTool.moveInterval = setInterval(function () { moveToolTip(vNewX, vNewY, pGanttChartObj.vTool, pTimer); }, pTimer);
   }


### PR DESCRIPTION
1. Tooltip content stored as data property instead of being injected in DOM. Really usefull on complex html templates along with large task list (350+)

2. If last tooltip position is out of current screen, moving animation is skipped - usefull on large task list 
i.e. mouseover task #1 (show tooltip) and then scroll to the last task (#350 or more) mouseover actual behavior: tooltip takes much time to move to current position (could reproduce it in demo with bigdata.json)