### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A fully featured gantt chart component built entirely in Javascript, CSS and AJA
 ![Demo Image](/docs/demo.gif)
 
 
-Start using with including the files `jsgantt.js` and `jsgantt.css` that are inside `docs/` folder.
+Start using with including the files `jsgantt.js` and `jsgantt.css` that are inside `dist/` folder.
 
 Or install and use in JS 
 


### PR DESCRIPTION
There's no jsgantt.js and jsgantt.css under docs folder. They are under dist folder

files under docs: https://github.com/jsGanttImproved/jsgantt-improved/tree/master/docs
files under dist: https://github.com/jsGanttImproved/jsgantt-improved/tree/master/dist