### PR TITLE
fix typo in pDataObject

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -395,7 +395,7 @@ export const TaskItem = function (pID, pName, pStart, pEnd, pClass, pLink, pMile
       pComp: vComp,
       pCost: vCost,
       pGroup: vGroup,
-      pDataObjec: vDataObject
+      pDataObject: vDataObject
     }
   }
 };


### PR DESCRIPTION
fix typo in result structure of TaskItem.getAllData()