### PR TITLE
fix: separate createElement from appendChild in newNode (#345)

### DIFF
--- a/src/utils/draw_utils.ts
+++ b/src/utils/draw_utils.ts
@@ -34,7 +34,8 @@ export const makeInput = function (formattedValue, editable, type = 'text', valu
 
 export const newNode = function (pParent, pNodeType, pId = null, pClass = null, pText = null,
   pWidth = null, pLeft = null, pDisplay = null, pColspan = null, pAttribs = null) {
-  let vNewNode = pParent.appendChild(document.createElement(pNodeType));
+  let vNewNode = document.createElement(pNodeType);
+  pParent.appendChild(vNewNode);
   if (pAttribs) {
     for (let i = 0; i + 1 < pAttribs.length; i += 2) {
       vNewNode.setAttribute(pAttribs[i], pAttribs[i + 1]);


### PR DESCRIPTION
## Summary

Fixes #345.

In some environments (custom DOM shims, Angular SSR, certain polyfills) `pParent.appendChild()` either throws `"appendChild is not a function"` or returns `undefined` instead of the appended node. The one-liner:

```ts
let vNewNode = pParent.appendChild(document.createElement(pNodeType));
```

…chains both calls, meaning if `appendChild` doesn't return the child, `vNewNode` is `undefined` and all subsequent property assignments (`id`, `className`, `style`, etc.) throw.

The fix separates the two operations so `vNewNode` is always the created element, regardless of what `appendChild` returns:

```ts
let vNewNode = document.createElement(pNodeType);
pParent.appendChild(vNewNode);
```

## Test plan

- [x] All 126 existing unit tests pass (`npm run test-file`)
- [x] TypeScript build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)