### PR TITLE
feat(#346): add setTooltipTemplateDelimiter for custom tooltip template delimiters

### DIFF
--- a/dist/jsgantt.js
+++ b/dist/jsgantt.js
@@ -142,6 +142,8 @@ var GanttChart = function (pDiv, pFormat) {
     this.vTimer = 20;
     this.vTooltipDelay = 1500;
     this.vTooltipTemplate = null;
+    this.vTooltipTemplateDelimiterOpen = '{{';
+    this.vTooltipTemplateDelimiterClose = '}}';
     this.vMinDate = null;
     this.vMaxDate = null;
     this.includeGetSet = options_1.includeGetSet.bind(this);
@@ -640,14 +642,14 @@ var GanttChart = function (pDiv, pFormat) {
             // Add Task Info div for tooltip
             if (this.vTaskList[i].getTaskDiv() && vTmpDiv_1) {
                 var vTmpDiv2 = (0, draw_utils_1.newNode)(vTmpDiv_1, "div", this.vDivId + "tt" + vID, null, null, null, null, "none");
-                var _a = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate), component = _a.component, callback = _a.callback;
+                var _a = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate, this.vTooltipTemplateDelimiterOpen, this.vTooltipTemplateDelimiterClose), component = _a.component, callback = _a.callback;
                 vTmpDiv2.appendChild(component);
                 (0, events_1.addTooltipListeners)(this, this.vTaskList[i].getTaskDiv(), vTmpDiv2, callback);
             }
             // Add Plan Task Info div for tooltip
             if (this.vTaskList[i].getPlanTaskDiv() && vTmpDiv_1) {
                 var vTmpDiv2 = (0, draw_utils_1.newNode)(vTmpDiv_1, "div", this.vDivId + "tt" + vID, null, null, null, null, "none");
-                var _b = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate), component = _b.component, callback = _b.callback;
+                var _b = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate, this.vTooltipTemplateDelimiterOpen, this.vTooltipTemplateDelimiterClose), component = _b.component, callback = _b.callback;
                 vTmpDiv2.appendChild(component);
                 (0, events_1.addTooltipListeners)(this, this.vTaskList[i].getPlanTaskDiv(), vTmpDiv2, callback);
             }
@@ -3568,6 +3570,7 @@ var includeGetSet = function () {
     this.setTimer = function (pVal) { this.vTimer = pVal * 1; };
     this.setTooltipDelay = function (pVal) { this.vTooltipDelay = pVal * 1; };
     this.setTooltipTemplate = function (pVal) { this.vTooltipTemplate = pVal; };
+    this.setTooltipTemplateDelimiter = function (open, close) { this.vTooltipTemplateDelimiterOpen = open; this.vTooltipTemplateDelimiterClose = close; };
     this.setMinDate = function (pVal) { this.vMinDate = pVal; };
     this.setMaxDate = function (pVal) { this.vMaxDate = pVal; };
     this.addLang = function (pLang, pVals) {
@@ -4158,9 +4161,11 @@ exports.TaskItem = TaskItem;
  *        If function(task): Promise<string>) - async per task template. Tooltip will show 'Loading...' if promise is not yet complete.
  *          Otherwise returned template will be handled in the same manner as in other cases.
  */
-var createTaskInfo = function (pTask, templateStrOrFn) {
+var createTaskInfo = function (pTask, templateStrOrFn, delimOpen, delimClose) {
     var _this = this;
     if (templateStrOrFn === void 0) { templateStrOrFn = null; }
+    if (delimOpen === void 0) { delimOpen = '{{'; }
+    if (delimClose === void 0) { delimClose = '}}'; }
     var vTmpDiv;
     var vTaskInfoBox = document.createDocumentFragment();
     var vTaskInfo = (0, draw_utils_1.newNode)(vTaskInfoBox, 'div', null, 'gTaskInfo');
@@ -4177,12 +4182,12 @@ var createTaskInfo = function (pTask, templateStrOrFn) {
                     lang = key;
                 }
                 var val = allData_1[key];
-                template = template.replace("{{".concat(key, "}}"), val);
+                template = template.replace("".concat(delimOpen).concat(key).concat(delimClose), val);
                 if (lang) {
-                    template = template.replace("{{Lang:".concat(key, "}}"), lang);
+                    template = template.replace("".concat(delimOpen, "Lang:").concat(key).concat(delimClose), lang);
                 }
                 else {
-                    template = template.replace("{{Lang:".concat(key, "}}"), key);
+                    template = template.replace("".concat(delimOpen, "Lang:").concat(key).concat(delimClose), key);
                 }
             });
             (0, draw_utils_1.newNode)(vTaskInfo, 'span', null, 'gTtTemplate', template);
@@ -4842,7 +4847,8 @@ var newNode = function (pParent, pNodeType, pId, pClass, pText, pWidth, pLeft, p
     if (pDisplay === void 0) { pDisplay = null; }
     if (pColspan === void 0) { pColspan = null; }
     if (pAttribs === void 0) { pAttribs = null; }
-    var vNewNode = pParent.appendChild(document.createElement(pNodeType));
+    var vNewNode = document.createElement(pNodeType);
+    pParent.appendChild(vNewNode);
     if (pAttribs) {
         for (var i = 0; i + 1 < pAttribs.length; i += 2) {
             vNewNode.setAttribute(pAttribs[i], pAttribs[i + 1]);

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -364,6 +364,28 @@
         </tr>
         <tr style="border-top:1px solid #ffe082">
           <td style="padding:6px 8px;vertical-align:top">
+            <a href="https://github.com/jsGanttImproved/jsgantt-improved/issues/346" target="_blank" style="color:#0066cc">#346</a>
+          </td>
+          <td style="padding:6px 8px;vertical-align:top" colspan="2">
+            <strong>Configurable tooltip template delimiters.</strong><br>
+            Django (and other frameworks) already use <code>{{ }}</code> in their template engines, conflicting with
+            the default tooltip template syntax. <code>setTooltipTemplateDelimiter(open, close)</code> lets you choose
+            any alternative pair of strings as delimiters.
+            <br><br>
+            <button onclick="load346Demo('default')" style="padding:4px 10px;margin-right:8px">Default delimiters <code>{{ }}</code></button>
+            <button onclick="load346Demo('custom')" style="padding:4px 10px;margin-right:8px">Custom delimiters <code>{[ ]}</code></button>
+            <br><br>
+            <div id="demo346-info" style="display:none;font-family:monospace;font-size:12px;line-height:1.7">
+              <span style="font-family:sans-serif">Active template: </span>
+              <span id="demo346-template" style="color:#0066cc"></span><br>
+              <span style="font-family:sans-serif">Delimiters: </span>
+              <span id="demo346-delimiters" style="color:#0066cc"></span><br>
+              <span style="font-family:sans-serif;color:#888">→ Hover over any task bar to see the tooltip.</span>
+            </div>
+          </td>
+        </tr>
+        <tr style="border-top:1px solid #ffe082">
+          <td style="padding:6px 8px;vertical-align:top">
             <a href="https://github.com/jsGanttImproved/jsgantt-improved/issues/376" target="_blank" style="color:#0066cc">#376</a>
           </td>
           <td style="padding:6px 8px;vertical-align:top" colspan="2">

--- a/docs/index.js
+++ b/docs/index.js
@@ -369,6 +369,43 @@ function demo376Remove() {
   }
 }
 
+// ─── Issue #346 demo ─────────────────────────────────────────────────────────
+// Demonstrates setTooltipTemplateDelimiter(open, close).
+// Django and other frameworks use {{ }} in their own template engines, which
+// conflicts with jsGantt's default tooltip template syntax. This demo lets you
+// switch between the default {{ }} delimiters and a custom {[ ]} pair.
+
+function load346Demo(mode) {
+  const useCustom = mode === 'custom';
+  const open  = useCustom ? '{[' : '{{';
+  const close = useCustom ? ']}' : '}}';
+  const tmpl  = `<div><strong>${open}pName${close}</strong></div>`
+              + `<div>Resource: ${open}pRes${close}</div>`
+              + `<div>Start: ${open}pStart${close} → End: ${open}pEnd${close}</div>`;
+
+  g = new JSGantt.GanttChart(document.getElementById("embedded-Gantt"), "month");
+  g.setOptions({
+    vFormat: "month",
+    vFormatArr: ["Week", "Month"],
+    vShowRes: 1, vShowCost: 0, vShowComp: 0, vShowDur: 0,
+    vShowStartDate: 1, vShowEndDate: 1,
+    vShowTaskInfoLink: 1,
+    vEditable: false,
+    vTooltipTemplate: tmpl,
+  });
+  if (useCustom) g.setTooltipTemplateDelimiter(open, close);
+
+  g.AddTaskItem(new JSGantt.TaskItem(1, "Design",     "2026-04-01", "2026-04-14", "gtaskblue",  "", 0, "Alice",   0, 0, 0, 1, "", "", "", g));
+  g.AddTaskItem(new JSGantt.TaskItem(2, "Development","2026-04-07", "2026-04-28", "gtaskgreen", "", 0, "Bob",     0, 0, 0, 1, "1", "", "", g));
+  g.AddTaskItem(new JSGantt.TaskItem(3, "QA Review",  "2026-04-21", "2026-04-30", "gtaskyellow","", 0, "Charlie", 0, 0, 0, 1, "2", "", "", g));
+  g.Draw();
+
+  document.getElementById("demo346-info").style.display = "block";
+  document.getElementById("demo346-template").textContent = tmpl;
+  document.getElementById("demo346-delimiters").textContent =
+    useCustom ? `open="${open}"  close="${close}"  (custom — Django-safe)` : `open="${open}"  close="${close}"  (default)`;
+}
+
 function load68Demo(workingDays) {
   g = new JSGantt.GanttChart(document.getElementById("embedded-Gantt"), "day");
   g.setOptions({

--- a/docs/jsgantt.js
+++ b/docs/jsgantt.js
@@ -142,6 +142,8 @@ var GanttChart = function (pDiv, pFormat) {
     this.vTimer = 20;
     this.vTooltipDelay = 1500;
     this.vTooltipTemplate = null;
+    this.vTooltipTemplateDelimiterOpen = '{{';
+    this.vTooltipTemplateDelimiterClose = '}}';
     this.vMinDate = null;
     this.vMaxDate = null;
     this.includeGetSet = options_1.includeGetSet.bind(this);
@@ -640,14 +642,14 @@ var GanttChart = function (pDiv, pFormat) {
             // Add Task Info div for tooltip
             if (this.vTaskList[i].getTaskDiv() && vTmpDiv_1) {
                 var vTmpDiv2 = (0, draw_utils_1.newNode)(vTmpDiv_1, "div", this.vDivId + "tt" + vID, null, null, null, null, "none");
-                var _a = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate), component = _a.component, callback = _a.callback;
+                var _a = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate, this.vTooltipTemplateDelimiterOpen, this.vTooltipTemplateDelimiterClose), component = _a.component, callback = _a.callback;
                 vTmpDiv2.appendChild(component);
                 (0, events_1.addTooltipListeners)(this, this.vTaskList[i].getTaskDiv(), vTmpDiv2, callback);
             }
             // Add Plan Task Info div for tooltip
             if (this.vTaskList[i].getPlanTaskDiv() && vTmpDiv_1) {
                 var vTmpDiv2 = (0, draw_utils_1.newNode)(vTmpDiv_1, "div", this.vDivId + "tt" + vID, null, null, null, null, "none");
-                var _b = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate), component = _b.component, callback = _b.callback;
+                var _b = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate, this.vTooltipTemplateDelimiterOpen, this.vTooltipTemplateDelimiterClose), component = _b.component, callback = _b.callback;
                 vTmpDiv2.appendChild(component);
                 (0, events_1.addTooltipListeners)(this, this.vTaskList[i].getPlanTaskDiv(), vTmpDiv2, callback);
             }
@@ -3568,6 +3570,7 @@ var includeGetSet = function () {
     this.setTimer = function (pVal) { this.vTimer = pVal * 1; };
     this.setTooltipDelay = function (pVal) { this.vTooltipDelay = pVal * 1; };
     this.setTooltipTemplate = function (pVal) { this.vTooltipTemplate = pVal; };
+    this.setTooltipTemplateDelimiter = function (open, close) { this.vTooltipTemplateDelimiterOpen = open; this.vTooltipTemplateDelimiterClose = close; };
     this.setMinDate = function (pVal) { this.vMinDate = pVal; };
     this.setMaxDate = function (pVal) { this.vMaxDate = pVal; };
     this.addLang = function (pLang, pVals) {
@@ -4158,9 +4161,11 @@ exports.TaskItem = TaskItem;
  *        If function(task): Promise<string>) - async per task template. Tooltip will show 'Loading...' if promise is not yet complete.
  *          Otherwise returned template will be handled in the same manner as in other cases.
  */
-var createTaskInfo = function (pTask, templateStrOrFn) {
+var createTaskInfo = function (pTask, templateStrOrFn, delimOpen, delimClose) {
     var _this = this;
     if (templateStrOrFn === void 0) { templateStrOrFn = null; }
+    if (delimOpen === void 0) { delimOpen = '{{'; }
+    if (delimClose === void 0) { delimClose = '}}'; }
     var vTmpDiv;
     var vTaskInfoBox = document.createDocumentFragment();
     var vTaskInfo = (0, draw_utils_1.newNode)(vTaskInfoBox, 'div', null, 'gTaskInfo');
@@ -4177,12 +4182,12 @@ var createTaskInfo = function (pTask, templateStrOrFn) {
                     lang = key;
                 }
                 var val = allData_1[key];
-                template = template.replace("{{".concat(key, "}}"), val);
+                template = template.replace("".concat(delimOpen).concat(key).concat(delimClose), val);
                 if (lang) {
-                    template = template.replace("{{Lang:".concat(key, "}}"), lang);
+                    template = template.replace("".concat(delimOpen, "Lang:").concat(key).concat(delimClose), lang);
                 }
                 else {
-                    template = template.replace("{{Lang:".concat(key, "}}"), key);
+                    template = template.replace("".concat(delimOpen, "Lang:").concat(key).concat(delimClose), key);
                 }
             });
             (0, draw_utils_1.newNode)(vTaskInfo, 'span', null, 'gTtTemplate', template);
@@ -4842,7 +4847,8 @@ var newNode = function (pParent, pNodeType, pId, pClass, pText, pWidth, pLeft, p
     if (pDisplay === void 0) { pDisplay = null; }
     if (pColspan === void 0) { pColspan = null; }
     if (pAttribs === void 0) { pAttribs = null; }
-    var vNewNode = pParent.appendChild(document.createElement(pNodeType));
+    var vNewNode = document.createElement(pNodeType);
+    pParent.appendChild(vNewNode);
     if (pAttribs) {
         for (var i = 0; i + 1 < pAttribs.length; i += 2) {
             vNewNode.setAttribute(pAttribs[i], pAttribs[i + 1]);

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -148,6 +148,8 @@ export const GanttChart = function (pDiv, pFormat) {
   this.vTimer = 20;
   this.vTooltipDelay = 1500;
   this.vTooltipTemplate = null;
+  this.vTooltipTemplateDelimiterOpen = '{{';
+  this.vTooltipTemplateDelimiterClose = '}}';
   this.vMinDate = null;
   this.vMaxDate = null;
   this.includeGetSet = includeGetSet.bind(this);
@@ -714,14 +716,14 @@ export const GanttChart = function (pDiv, pFormat) {
       // Add Task Info div for tooltip
       if (this.vTaskList[i].getTaskDiv() && vTmpDiv) {
         const vTmpDiv2 = newNode(vTmpDiv, "div", this.vDivId + "tt" + vID, null, null, null, null, "none");
-        const { component, callback } = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate);
+        const { component, callback } = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate, this.vTooltipTemplateDelimiterOpen, this.vTooltipTemplateDelimiterClose);
         vTmpDiv2.appendChild(component);
         addTooltipListeners(this, this.vTaskList[i].getTaskDiv(), vTmpDiv2, callback);
       }
       // Add Plan Task Info div for tooltip
       if (this.vTaskList[i].getPlanTaskDiv() && vTmpDiv) {
         const vTmpDiv2 = newNode(vTmpDiv, "div", this.vDivId + "tt" + vID, null, null, null, null, "none");
-        const { component, callback } = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate);
+        const { component, callback } = this.createTaskInfo(this.vTaskList[i], this.vTooltipTemplate, this.vTooltipTemplateDelimiterOpen, this.vTooltipTemplateDelimiterClose);
         vTmpDiv2.appendChild(component);
         addTooltipListeners(this, this.vTaskList[i].getPlanTaskDiv(), vTmpDiv2, callback);
       }

--- a/src/options.ts
+++ b/src/options.ts
@@ -108,6 +108,7 @@ export const includeGetSet = function () {
   this.setTimer = function (pVal) { this.vTimer = pVal * 1; };
   this.setTooltipDelay = function (pVal) { this.vTooltipDelay = pVal * 1; };
   this.setTooltipTemplate = function (pVal) { this.vTooltipTemplate = pVal; };
+  this.setTooltipTemplateDelimiter = function (open, close) { this.vTooltipTemplateDelimiterOpen = open; this.vTooltipTemplateDelimiterClose = close; };
   this.setMinDate = function (pVal) { this.vMinDate = pVal; };
   this.setMaxDate = function (pVal) { this.vMaxDate = pVal; };
   this.addLang = function (pLang, pVals) {

--- a/src/task.ts
+++ b/src/task.ts
@@ -413,7 +413,7 @@ export const TaskItem = function (pID, pName, pStart, pEnd, pClass, pLink, pMile
  *        If function(task): Promise<string>) - async per task template. Tooltip will show 'Loading...' if promise is not yet complete.
  *          Otherwise returned template will be handled in the same manner as in other cases.
  */
-export const createTaskInfo = function (pTask, templateStrOrFn = null) {
+export const createTaskInfo = function (pTask, templateStrOrFn = null, delimOpen = '{{', delimClose = '}}') {
   let vTmpDiv;
   let vTaskInfoBox = document.createDocumentFragment();
   let vTaskInfo = newNode(vTaskInfoBox, 'div', null, 'gTaskInfo');
@@ -433,11 +433,11 @@ export const createTaskInfo = function (pTask, templateStrOrFn = null) {
         }
         const val = allData[key];
 
-        template = template.replace(`{{${key}}}`, val);
+        template = template.replace(`${delimOpen}${key}${delimClose}`, val);
         if (lang) {
-          template = template.replace(`{{Lang:${key}}}`, lang);
+          template = template.replace(`${delimOpen}Lang:${key}${delimClose}`, lang);
         } else {
-          template = template.replace(`{{Lang:${key}}}`, key);
+          template = template.replace(`${delimOpen}Lang:${key}${delimClose}`, key);
         }
       });
       newNode(vTaskInfo, 'span', null, 'gTtTemplate', template);

--- a/test/unit/tooltip-template-delimiter.spec.ts
+++ b/test/unit/tooltip-template-delimiter.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for issue #346 — configurable tooltip template delimiters.
+ *
+ * By default the tooltip template uses {{ }} which conflicts with Django's
+ * template engine. setTooltipTemplateDelimiter(open, close) lets users swap
+ * the delimiters to any pair of strings.
+ */
+
+import { expect } from 'chai';
+import { createTaskInfo, TaskItem } from '../../src/task';
+import { hashString } from '../../src/utils/general_utils';
+
+// ─── Mock DOM helpers ─────────────────────────────────────────────────────────
+
+function makeTextNode(val: any) {
+  return { _type: 'text', data: String(val == null ? '' : val), childNodes: [] as any[] };
+}
+
+function makeElement(tag: string): any {
+  const children: any[] = [];
+  let _inner = '';
+  const el: any = {
+    _type: 'element',
+    nodeName: tag.toUpperCase(),
+    className: '',
+    childNodes: children,
+    style: {},
+    id: '',
+    colSpan: 0,
+    appendChild(child: any) { children.push(child); return child; },
+    setAttribute(_name: string, _val: any) {},
+    insertAdjacentHTML(_pos: string, html: string) {
+      children.push({ _type: 'raw', html });
+    },
+    hasChildNodes() { return children.length > 0; },
+    replaceChild(newNode: any, oldNode: any) {
+      const idx = children.indexOf(oldNode);
+      if (idx !== -1) children[idx] = newNode;
+    },
+  };
+  Object.defineProperty(el, 'innerHTML', {
+    get() { return _inner; },
+    set(v: string) { _inner = v; if (v === '') children.length = 0; },
+  });
+  return el;
+}
+
+function makeFragment(): any {
+  const children: any[] = [];
+  return {
+    _type: 'fragment',
+    childNodes: children,
+    appendChild(child: any) { children.push(child); return child; },
+  };
+}
+
+/** Recursively collect all text-node data from a mock DOM node. */
+function textContent(node: any): string {
+  if (!node) return '';
+  if (node._type === 'text') return node.data;
+  return (node.childNodes || []).map(textContent).join('');
+}
+
+/** Find the first node (BFS) whose className includes the given class. */
+function findByClass(node: any, cls: string): any {
+  if (node.className && node.className.includes(cls)) return node;
+  for (const child of node.childNodes || []) {
+    const found = findByClass(child, cls);
+    if (found) return found;
+  }
+  return null;
+}
+
+// ─── Minimal GanttChart context ───────────────────────────────────────────────
+
+function makeTask(name: string): any {
+  return new (TaskItem as any)(
+    1, name, '', '', 'gtaskblue', '', 0, '', 0, 0, 0, 1, null, '', '', {
+      getDateInputFormat: () => 'yyyy-mm-dd',
+      hashString,
+    }, 0, null, null,
+  );
+}
+
+const mockChart: any = {
+  vLang: 'en',
+  vLangs: { en: {} },
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('createTaskInfo — tooltip template delimiters', () => {
+  // Patch global.document to add createDocumentFragment (not in helpers.ts shim).
+  // We save and restore around the suite so other tests are unaffected.
+  let savedDoc: any;
+  before(() => {
+    savedDoc = (global as any).document;
+    (global as any).document = {
+      createTextNode: makeTextNode,
+      createElement:  makeElement,
+      createDocumentFragment: makeFragment,
+    };
+  });
+  after(() => {
+    (global as any).document = savedDoc;
+  });
+
+  it('default {{ }} delimiters substitute pName', () => {
+    const task = makeTask('My Task');
+    const { component } = createTaskInfo.call(mockChart, task, '{{pName}}');
+    const span = findByClass(component, 'gTtTemplate');
+    expect(textContent(span)).to.equal('My Task');
+  });
+
+  it('custom delimiters {[ ]} substitute pName', () => {
+    const task = makeTask('Django Task');
+    const { component } = createTaskInfo.call(mockChart, task, '{[pName]}', '{[', ']}');
+    const span = findByClass(component, 'gTtTemplate');
+    expect(textContent(span)).to.equal('Django Task');
+  });
+
+  it('default delimiters do NOT match a custom-delimited template', () => {
+    const task = makeTask('Should Not Match');
+    const { component } = createTaskInfo.call(mockChart, task, '{[pName]}');
+    const span = findByClass(component, 'gTtTemplate');
+    expect(textContent(span)).to.equal('{[pName]}');
+  });
+
+  it('custom delimiters do NOT match a default-delimited template', () => {
+    const task = makeTask('Should Not Match');
+    const { component } = createTaskInfo.call(mockChart, task, '{{pName}}', '{[', ']}');
+    const span = findByClass(component, 'gTtTemplate');
+    expect(textContent(span)).to.equal('{{pName}}');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `setTooltipTemplateDelimiter(open, close)` to the GanttChart API
- Defaults to `{{` / `}}` (no behaviour change for existing users)
- Resolves the conflict with Django's template engine (and any other system that uses `{{ }}` syntax)

## Usage

```js
const gantt = new JSGantt.GanttChart(document.getElementById('GanttChartDIV'), 'day');
// Use {[ ]} instead of {{ }} so Django templates are not affected
gantt.setTooltipTemplateDelimiter('{[', ']}');
gantt.setTooltipTemplate('<b>{[pName]}</b> — {[pRes]}');
```

## Changes

| File | Change |
|------|--------|
| `src/draw.ts` | Adds `vTooltipTemplateDelimiterOpen` / `vTooltipTemplateDelimiterClose` defaults; passes them to `createTaskInfo` |
| `src/options.ts` | Adds `setTooltipTemplateDelimiter(open, close)` setter |
| `src/task.ts` | `createTaskInfo` accepts `delimOpen` / `delimClose` parameters (default `{{` / `}}`) |
| `test/unit/tooltip-template-delimiter.spec.ts` | 4 unit tests covering default and custom delimiter behaviour |

## Test plan
- [ ] All 130 unit tests pass (`npm run test-file -- test/unit/tooltip-template-delimiter.spec.ts`)
- [ ] Build is clean (`npm run build`)
- [ ] Existing tooltip behaviour is unchanged when `setTooltipTemplateDelimiter` is not called

Fixes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)