### PR TITLE
fix(#381): sync header gtaskname column width when left panel is resized

### DIFF
--- a/dist/jsgantt.js
+++ b/dist/jsgantt.js
@@ -1166,7 +1166,7 @@ exports.DrawDependencies = DrawDependencies;
 },{}],5:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.addListenerDependencies = exports.addListenerInputCell = exports.addListenerClickCell = exports.addScrollListeners = exports.addFormatListeners = exports.addFolderListeners = exports.updateGridHeaderWidth = exports.addThisRowListeners = exports.addTooltipListeners = exports.syncScroll = exports.removeListener = exports.addListener = exports.showToolTip = exports.mouseOut = exports.mouseOver = exports.show = exports.hide = exports.folder = void 0;
+exports.addListenerDependencies = exports.addListenerInputCell = exports.addListenerClickCell = exports.addScrollListeners = exports.syncTaskNameHeaderWidth = exports.addFormatListeners = exports.addFolderListeners = exports.updateGridHeaderWidth = exports.addThisRowListeners = exports.addTooltipListeners = exports.syncScroll = exports.removeListener = exports.addListener = exports.showToolTip = exports.mouseOut = exports.mouseOver = exports.show = exports.hide = exports.folder = void 0;
 var general_utils_1 = require("./utils/general_utils");
 // Function to open/close and hide/show children of specified task
 var folder = function (pID, ganttObj) {
@@ -1458,11 +1458,35 @@ var addFormatListeners = function (pGanttChart, pFormat, pObj) {
     (0, exports.addListener)('click', function () { (0, general_utils_1.changeFormat)(pFormat, pGanttChart); }, pObj);
 };
 exports.addFormatListeners = addFormatListeners;
+var syncTaskNameHeaderWidth = function (pGanttChart) {
+    var listBody = pGanttChart.getListBody();
+    if (!listBody)
+        return;
+    var bodyCell = listBody.querySelector('table.gtasktable td.gtaskname');
+    var headerCell = listBody.querySelector('table.gtasktableh tr:nth-child(2) td.gtaskname');
+    if (bodyCell && headerCell) {
+        headerCell.style.minWidth = bodyCell.getBoundingClientRect().width + 'px';
+    }
+};
+exports.syncTaskNameHeaderWidth = syncTaskNameHeaderWidth;
 var addScrollListeners = function (pGanttChart) {
     (0, exports.addListener)('resize', function () { pGanttChart.getChartHead().scrollLeft = pGanttChart.getChartBody().scrollLeft; }, window);
     (0, exports.addListener)('resize', function () {
         pGanttChart.getListBody().scrollTop = pGanttChart.getChartBody().scrollTop;
     }, window);
+    // Sync header gtaskname column width when the left panel is resized
+    if (typeof ResizeObserver !== 'undefined') {
+        var listBody = pGanttChart.getListBody();
+        if (listBody) {
+            var leftPanel = listBody.closest('.gmainleft');
+            if (leftPanel) {
+                var observer = new ResizeObserver(function () {
+                    (0, exports.syncTaskNameHeaderWidth)(pGanttChart);
+                });
+                observer.observe(leftPanel);
+            }
+        }
+    }
 };
 exports.addScrollListeners = addScrollListeners;
 var addListenerClickCell = function (vTmpCell, vEvents, task, column) {

--- a/docs/jsgantt.js
+++ b/docs/jsgantt.js
@@ -1166,7 +1166,7 @@ exports.DrawDependencies = DrawDependencies;
 },{}],5:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.addListenerDependencies = exports.addListenerInputCell = exports.addListenerClickCell = exports.addScrollListeners = exports.addFormatListeners = exports.addFolderListeners = exports.updateGridHeaderWidth = exports.addThisRowListeners = exports.addTooltipListeners = exports.syncScroll = exports.removeListener = exports.addListener = exports.showToolTip = exports.mouseOut = exports.mouseOver = exports.show = exports.hide = exports.folder = void 0;
+exports.addListenerDependencies = exports.addListenerInputCell = exports.addListenerClickCell = exports.addScrollListeners = exports.syncTaskNameHeaderWidth = exports.addFormatListeners = exports.addFolderListeners = exports.updateGridHeaderWidth = exports.addThisRowListeners = exports.addTooltipListeners = exports.syncScroll = exports.removeListener = exports.addListener = exports.showToolTip = exports.mouseOut = exports.mouseOver = exports.show = exports.hide = exports.folder = void 0;
 var general_utils_1 = require("./utils/general_utils");
 // Function to open/close and hide/show children of specified task
 var folder = function (pID, ganttObj) {
@@ -1458,11 +1458,35 @@ var addFormatListeners = function (pGanttChart, pFormat, pObj) {
     (0, exports.addListener)('click', function () { (0, general_utils_1.changeFormat)(pFormat, pGanttChart); }, pObj);
 };
 exports.addFormatListeners = addFormatListeners;
+var syncTaskNameHeaderWidth = function (pGanttChart) {
+    var listBody = pGanttChart.getListBody();
+    if (!listBody)
+        return;
+    var bodyCell = listBody.querySelector('table.gtasktable td.gtaskname');
+    var headerCell = listBody.querySelector('table.gtasktableh tr:nth-child(2) td.gtaskname');
+    if (bodyCell && headerCell) {
+        headerCell.style.minWidth = bodyCell.getBoundingClientRect().width + 'px';
+    }
+};
+exports.syncTaskNameHeaderWidth = syncTaskNameHeaderWidth;
 var addScrollListeners = function (pGanttChart) {
     (0, exports.addListener)('resize', function () { pGanttChart.getChartHead().scrollLeft = pGanttChart.getChartBody().scrollLeft; }, window);
     (0, exports.addListener)('resize', function () {
         pGanttChart.getListBody().scrollTop = pGanttChart.getChartBody().scrollTop;
     }, window);
+    // Sync header gtaskname column width when the left panel is resized
+    if (typeof ResizeObserver !== 'undefined') {
+        var listBody = pGanttChart.getListBody();
+        if (listBody) {
+            var leftPanel = listBody.closest('.gmainleft');
+            if (leftPanel) {
+                var observer = new ResizeObserver(function () {
+                    (0, exports.syncTaskNameHeaderWidth)(pGanttChart);
+                });
+                observer.observe(leftPanel);
+            }
+        }
+    }
 };
 exports.addScrollListeners = addScrollListeners;
 var addListenerClickCell = function (vTmpCell, vEvents, task, column) {

--- a/src/events.ts
+++ b/src/events.ts
@@ -296,11 +296,35 @@ export const addFormatListeners = function (pGanttChart, pFormat, pObj) {
   addListener('click', function () { changeFormat(pFormat, pGanttChart); }, pObj);
 };
 
+export const syncTaskNameHeaderWidth = function (pGanttChart) {
+  const listBody = pGanttChart.getListBody();
+  if (!listBody) return;
+  const bodyCell = listBody.querySelector('table.gtasktable td.gtaskname');
+  const headerCell = listBody.querySelector('table.gtasktableh tr:nth-child(2) td.gtaskname');
+  if (bodyCell && headerCell) {
+    headerCell.style.minWidth = bodyCell.getBoundingClientRect().width + 'px';
+  }
+};
+
 export const addScrollListeners = function (pGanttChart) {
   addListener('resize', function () { pGanttChart.getChartHead().scrollLeft = pGanttChart.getChartBody().scrollLeft; }, window);
   addListener('resize', function () {
     pGanttChart.getListBody().scrollTop = pGanttChart.getChartBody().scrollTop;
   }, window);
+
+  // Sync header gtaskname column width when the left panel is resized
+  if (typeof ResizeObserver !== 'undefined') {
+    const listBody = pGanttChart.getListBody();
+    if (listBody) {
+      const leftPanel = listBody.closest('.gmainleft');
+      if (leftPanel) {
+        const observer = new ResizeObserver(function () {
+          syncTaskNameHeaderWidth(pGanttChart);
+        });
+        observer.observe(leftPanel);
+      }
+    }
+  }
 };
 
 export const addListenerClickCell = function (vTmpCell, vEvents, task, column) {


### PR DESCRIPTION
## Problem

When the user drags the resize handle on the left task-list panel, the `gtaskname` column in the **header** table (`gtasktableh`) does not track the width of the same column in the **body** table (`gtasktable`). The two tables are siblings in the DOM, each computing their own column widths independently, so resizing the panel causes the columns to fall out of alignment.

Closes #381.

## Root Cause

The left panel (`.gmainleft`) has `resize: horizontal` applied via CSS. Dragging it fires no `resize` event on the element — only a window-level `resize` fires for viewport changes. As a result, the existing scroll/resize listeners never run after a panel drag, and the header's `gtaskname` `min-width` stays at its initial computed value while the body column grows to fill the extra space.

## Fix

Add a `ResizeObserver` on `.gmainleft` inside `addScrollListeners`. Whenever the panel width changes the observer fires `syncTaskNameHeaderWidth`, which reads the current `getBoundingClientRect().width` of the first `td.gtaskname` in the body table and applies it as `min-width` on the second row's `td.gtaskname` in the header table — exactly the same logic as the reporter's workaround, but automatic and built in.

`syncTaskNameHeaderWidth` is also exported so callers can invoke it manually (e.g. in `afterDraw`) in environments that do not support `ResizeObserver`.

`ResizeObserver` is baseline-available in all modern browsers (Chrome 64+, Firefox 69+, Safari 13.1+, Edge 79+) and is guarded with a `typeof` check for safety.

## Test

1. Open http://test.counbo.com/jsgantt-improved/
2. Drag the right edge of the left task-list panel to make it wider or narrower.
3. Verify that the **Start Date / End Date** (and other column) headers stay aligned with the data rows at every width.

Before this fix the headers shift apart immediately; after the fix they remain aligned.